### PR TITLE
Fix unchecked reading boolean values

### DIFF
--- a/src/readbuffer.rs
+++ b/src/readbuffer.rs
@@ -314,8 +314,13 @@ where
         let bit_offset = position & 7;
 
         let byte = self.slice.get_unchecked(byte_index);
-        let shifted = byte >> bit_offset;
-        shifted & 1u8 == 1
+        if E::is_le() {
+            let shifted = byte >> bit_offset;
+            shifted & 1u8 == 1
+        } else {
+            let shifted = byte << bit_offset;
+            shifted & 0b1000_0000u8 == 0b1000_0000u8
+        }
     }
 
     /// Read a sequence of bits from the buffer as integer

--- a/tests/roundtrip.rs
+++ b/tests/roundtrip.rs
@@ -83,17 +83,26 @@ fn test_bare_enum() {
 #[test]
 fn test_field_enum() {
     #[derive(Debug, PartialEq, BitRead, BitWrite)]
+    struct CompoundVariant(
+        #[size = 15]
+        u16,
+        bool,
+    );
+
+    #[derive(Debug, PartialEq, BitRead, BitWrite)]
     #[discriminant_bits = 4]
     enum Enum {
         A,
         B(String),
         C(f32),
         D(#[size = 15] i64),
+        E(CompoundVariant),
     }
     roundtrip(Enum::A);
     roundtrip(Enum::B("foobar".into()));
     roundtrip(Enum::C(12.0));
     roundtrip(Enum::D(-12345));
+    roundtrip(Enum::E(CompoundVariant(6789, true)));
 }
 
 #[test]


### PR DESCRIPTION
While building a prototype with bitbuffer I noticed that the `BitReadBuffer::read_bool_unchecked` method doesn't take the endianess into account.