### PR TITLE
fixup: decrement before indexing with `last_mut`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,7 @@ pub use write::{BitWrite, BitWriteSized};
 pub use writestream::BitWriteStream;
 
 mod endianness;
+#[allow(missing_docs)]
 pub mod num_traits;
 mod read;
 mod readbuffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,7 +88,7 @@ pub use write::{BitWrite, BitWriteSized};
 pub use writestream::BitWriteStream;
 
 mod endianness;
-mod num_traits;
+pub mod num_traits;
 mod read;
 mod readbuffer;
 mod readstream;

--- a/src/readbuffer.rs
+++ b/src/readbuffer.rs
@@ -26,7 +26,7 @@ pub(crate) enum Data<'a> {
 impl<'a> Data<'a> {
     pub fn as_slice(&self) -> &[u8] {
         match self {
-            Data::Borrowed(bytes) => *bytes,
+            Data::Borrowed(bytes) => bytes,
             Data::Owned(bytes) => bytes.borrow(),
         }
     }
@@ -71,7 +71,7 @@ impl<'a> Index<usize> for Data<'a> {
 impl<'a> Clone for Data<'a> {
     fn clone(&self) -> Self {
         match self {
-            Data::Borrowed(bytes) => Data::Borrowed(*bytes),
+            Data::Borrowed(bytes) => Data::Borrowed(bytes),
             Data::Owned(bytes) => Data::Owned(Rc::clone(bytes)),
         }
     }

--- a/src/write.rs
+++ b/src/write.rs
@@ -209,7 +209,7 @@ impl<'a, T: BitWrite<E> + ToOwned + ?Sized, E: Endianness> BitWrite<E> for Cow<'
 
 macro_rules! impl_write_tuple {
     ($($i:tt: $type:ident),*) => {
-        impl<'a, E: Endianness, $($type: BitWrite<E>),*> BitWrite<E> for ($($type),*) {
+        impl<E: Endianness, $($type: BitWrite<E>),*> BitWrite<E> for ($($type),*) {
             #[inline]
             fn write(&self, stream: &mut BitWriteStream<E>) -> Result<()> {
                 $(self.$i.write(stream)?;)*

--- a/src/writebuffer.rs
+++ b/src/writebuffer.rs
@@ -45,7 +45,7 @@ impl<'a> WriteData<'a> {
     fn last_mut(&mut self) -> Option<&mut u8> {
         match self {
             WriteData::Vec(vec) => vec.last_mut(),
-            WriteData::Slice { data, length } if *length > 0 => Some(&mut data[*length]),
+            WriteData::Slice { data, length } if *length > 0 => Some(&mut data[*length - 1]),
             _ => None,
         }
     }

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -230,16 +230,16 @@ fn test_write_to_slice() {
 
 #[test]
 fn test_write_last_slice() {
-  let mut data = [0; 1];
-  {
-    let mut stream = BitWriteStream::from_slice(&mut data[..], LittleEndian);
+    let mut data = [0; 1];
+    {
+        let mut stream = BitWriteStream::from_slice(&mut data[..], LittleEndian);
 
-    stream.write_int::<u8>(0b1000, 4).unwrap();
-    stream.write_bool(true).unwrap();
-  }
+        stream.write_int::<u8>(0b1000, 4).unwrap();
+        stream.write_bool(true).unwrap();
+    }
 
-  let mut read = BitReadStream::from(BitReadBuffer::new(&data[..], LittleEndian));
+    let mut read = BitReadStream::from(BitReadBuffer::new(&data[..], LittleEndian));
 
-  assert_eq!(0b1000, read.read_int::<u8>(4).unwrap());
-  assert_eq!(true, read.read_bool().unwrap());
+    assert_eq!(0b1000, read.read_int::<u8>(4).unwrap());
+    assert_eq!(true, read.read_bool().unwrap());
 }

--- a/tests/write_tests.rs
+++ b/tests/write_tests.rs
@@ -227,3 +227,19 @@ fn test_write_to_slice() {
     // 0 padded
     assert_eq!(false, read.read_bool().unwrap());
 }
+
+#[test]
+fn test_write_last_slice() {
+  let mut data = [0; 1];
+  {
+    let mut stream = BitWriteStream::from_slice(&mut data[..], LittleEndian);
+
+    stream.write_int::<u8>(0b1000, 4).unwrap();
+    stream.write_bool(true).unwrap();
+  }
+
+  let mut read = BitReadStream::from(BitReadBuffer::new(&data[..], LittleEndian));
+
+  assert_eq!(0b1000, read.read_int::<u8>(4).unwrap());
+  assert_eq!(true, read.read_bool().unwrap());
+}


### PR DESCRIPTION
We were not indexing the correct element in `last_mut`, which would lead to panic or even worse, incorrect result (my case), if you were providing a precomputed slice to write on, the actual byte + 1 would have been set when using `write_bool` :).
I also made the `num_traits` module public as it's otherwise impossible to have an abstraction layer on top of the library, a.k.a. having a generic function constraining the type to the one expected by `write_int` for instance.