### PR TITLE
Re-introduce the align function & add #[align] attribute

### DIFF
--- a/src/readstream.rs
+++ b/src/readstream.rs
@@ -423,6 +423,45 @@ where
         }
     }
 
+    /// Align the stream on the next byte and returns the amount of bits read
+    ///
+    /// # Errors
+    ///
+    /// - [`ReadError::NotEnoughData`]: not enough bits available in the stream to skip
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitbuffer::{BitReadBuffer, BitReadStream, LittleEndian, Result};
+    /// #
+    /// # fn main() -> Result<()> {
+    /// # let bytes = vec![
+    /// #     0b1011_0101, 0b0110_1010, 0b1010_1100, 0b1001_1001,
+    /// #     0b1001_1001, 0b1001_1001, 0b1001_1001, 0b1110_0111
+    /// # ];
+    /// # let buffer = BitReadBuffer::new(&bytes, LittleEndian);
+    /// # let mut stream = BitReadStream::new(buffer);
+    /// stream.align()?;
+    /// assert_eq!(stream.pos(), 0);
+    ///
+    /// stream.skip_bits(3)?;
+    /// assert_eq!(stream.pos(), 3);
+    /// stream.align();
+    /// assert_eq!(stream.pos(), 8);
+    /// assert_eq!(stream.read_int::<u8>(4)?, 0b1010);
+    /// #
+    /// #     Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`ReadError::NotEnoughData`]: enum.ReadError.html#variant.NotEnoughData
+    pub fn align(&mut self) -> Result<usize> {
+        match self.pos % 8 {
+            0 => Ok(0),
+            n => self.skip_bits(8 - n).map(|_| 8 - n),
+        }
+    }
+
     /// Set the position of the stream
     ///
     /// # Errors

--- a/src/writestream.rs
+++ b/src/writestream.rs
@@ -98,6 +98,38 @@ where
         }
     }
 
+    /// Align the stream on the next byte by writing zero bits and returns the amount of bits written
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use bitbuffer::{BitReadBuffer, LittleEndian, Result};
+    /// #
+    /// # fn main() -> Result<()> {
+    /// # use bitbuffer::{BitWriteStream, LittleEndian};
+    ///
+    /// let mut data = Vec::new();
+    /// let mut stream = BitWriteStream::new(&mut data, LittleEndian);
+    /// stream.write_bool(true)?;
+    /// stream.align();
+    /// assert_eq!(stream.bit_len(), 8);
+    /// assert_eq!(data, [0b0000_0001]);
+    /// #
+    /// #     Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`ReadError::NotEnoughData`]: enum.ReadError.html#variant.NotEnoughData
+    pub fn align(&mut self) -> usize {
+        match self.bit_len() % 8 {
+            0 => 0,
+            n => {
+                self.push_bits(0, 8 - n);
+                8 - n
+            }
+        }
+    }
+
     /// Write a boolean into the buffer
     ///
     /// # Examples


### PR DESCRIPTION
Re-introduce `.align` function from #1, also implementing it on `BitStreamWriter`

Also add the #[align] attribute:
    
It can be applied to enums & structs to align before reading any fields or the discriminant
    
It can also be applied to individual struct fields to align the reader before reading the field
    
Finally, you can apply it to non-unit enum variants to align the reader after reading the discriminant, but before reading the payload
