### PR TITLE
fix `unsafe_op_in_unsafe_fn` in generated code on 2024 edition

### DIFF
--- a/bitbuffer_derive/src/read/enum.rs
+++ b/bitbuffer_derive/src/read/enum.rs
@@ -35,6 +35,12 @@ pub fn derive_encode_enum(params: &EnumParam, unchecked: bool) -> TokenStream {
             }
         });
 
+    let r#unsafe = if unchecked {
+        quote_spanned!(span => unsafe)
+    } else {
+        quote_spanned!(span =>)
+    };
+
     let read_fn = Ident::new(
         if unchecked {
             "read_int_unchecked"
@@ -58,7 +64,7 @@ pub fn derive_encode_enum(params: &EnumParam, unchecked: bool) -> TokenStream {
 
     quote_spanned! {span =>
         #[allow(clippy::unnecessary_cast)]
-        let discriminant:#repr = __stream.#read_fn(#discriminant_bits as usize, #end_param)#error_handle;
+        let discriminant:#repr = #r#unsafe { __stream.#read_fn(#discriminant_bits as usize, #end_param)#error_handle };
         match discriminant {
             #(#match_arms)*
             _ => {

--- a/bitbuffer_derive/src/read/field.rs
+++ b/bitbuffer_derive/src/read/field.rs
@@ -14,6 +14,12 @@ pub fn read_struct_or_enum(
         let align = &f.align;
         let field_type = &f.ty;
         let span = f.span();
+        let r#unsafe = if unchecked {
+            quote_spanned!(span => unsafe)
+        } else {
+            quote_spanned!(span =>)
+        };
+
         let read_fn = Ident::new(if unchecked { "read_unchecked" } else { "read" }, span);
         let read_sized_fn = Ident::new(
             if unchecked {
@@ -31,7 +37,7 @@ pub fn read_struct_or_enum(
         match &f.size {
             Some(size) => {
                 quote_spanned! { span =>
-                    {
+                    #r#unsafe {
                         #align
                         let _size: usize = #size;
                         __stream.#read_sized_fn::<#field_type>(_size, #end_param)?
@@ -40,7 +46,7 @@ pub fn read_struct_or_enum(
             }
             None => {
                 quote_spanned! { span =>
-                    {
+                    #r#unsafe {
                         #align
                         __stream.#read_fn::<#field_type>(#end_param)?
                     }


### PR DESCRIPTION
2024 edition was released on stable with Rust 1.85 today.

This PR fixes `unsafe_op_in_unsafe_fn` lint in generated code by wrapping unchecked method calls with an unsafe block.

This prevents warnings being issued when derive is used in crates that are on 2024 edition